### PR TITLE
Fix for EventActions in 1.19

### DIFF
--- a/m_EventActions/src/net/slipcor/pvparena/modules/eventactions/EventActions.java
+++ b/m_EventActions/src/net/slipcor/pvparena/modules/eventactions/EventActions.java
@@ -31,6 +31,8 @@ public class EventActions extends ArenaModule {
         super("EventActions");
     }
 
+    private PAListener listener;
+
     @Override
     public String version() {
         return getClass().getPackage().getImplementationVersion();
@@ -65,7 +67,8 @@ public class EventActions extends ArenaModule {
         if (setup) {
             return;
         }
-        Bukkit.getPluginManager().registerEvents(new PAListener(this), PVPArena.instance);
+        //Bukkit.getPluginManager().registerEvents(new PAListener(this), PVPArena.instance);
+        this.getListener();
         setup = true;
     }
 
@@ -199,5 +202,13 @@ public class EventActions extends ArenaModule {
                 p.sendMessage(split[1]);
             }
         }
+    }
+
+    private PAListener getListener() {
+        if (listener == null) {
+            listener = new PAListener(this);
+            Bukkit.getPluginManager().registerEvents(listener, PVPArena.instance);
+        }
+        return listener;
     }
 }

--- a/m_EventActions/src/net/slipcor/pvparena/modules/eventactions/PAListener.java
+++ b/m_EventActions/src/net/slipcor/pvparena/modules/eventactions/PAListener.java
@@ -30,7 +30,7 @@ class PAListener implements Listener {
         final Player p = event.getPlayer();
         ea.catchEvent("death", p, a);
     }
-
+ 
     @EventHandler
     public void onEnd(final PAEndEvent event) {
         final Arena a = event.getArena();
@@ -44,7 +44,7 @@ class PAListener implements Listener {
         ea.catchEvent("exit", p, a);
     }
 
-    @EventHandler
+     @EventHandler
     public void onJoin(final PAJoinEvent event) {
         final Arena a = event.getArena();
         final Player p = event.getPlayer();
@@ -104,13 +104,13 @@ class PAListener implements Listener {
 
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
-    public boolean playerInteract(final PlayerInteractEvent event) {
+    public void onPlayerInteract(final PlayerInteractEvent event) {
         if (!event.hasBlock()) {
-            return false;
+            return;
         }
-
+ 
         if (event.getHand() == null || event.getHand().equals(EquipmentSlot.OFF_HAND)) {
-            return false;
+            return;
         }
 //		debug.i("interact eventactions", event.getPlayer());
         final Arena a = PAA_Edit.activeEdits.get(event.getPlayer().getName() + "_power");
@@ -129,7 +129,7 @@ class PAListener implements Listener {
                     );
                     if (loc.equals(locc.toLocation())) {
                         PVPArena.instance.getLogger().warning("Block already exists!");
-                        return true;
+                        return;
                     }
 
                     node = node.replace(s, "");
@@ -141,9 +141,9 @@ class PAListener implements Listener {
 
             SpawnManager.setBlock(a, new PABlockLocation(loc), s + i);
             Arena.pmsg(event.getPlayer(), Language.parse(MSG.SPAWN_SET, s + i));
-            return true;
+            return;
         }
 
-        return false;
+        return;
     }
 }


### PR DESCRIPTION
PAListener.playerInteract() shouldn't be a boolean method. If it is - the exception occurs. 
I'm not even sure why it's boolean, as we're not passing the output anywhere.
If someone wanted to insert 'breaks' (as in loops) in a method which depend on some values (eg. !event.hasBlock()) - we should use only the return statement, without value.